### PR TITLE
New way to get the tokens

### DIFF
--- a/native/src/driver_app.erl
+++ b/native/src/driver_app.erl
@@ -3,7 +3,7 @@
 -behaviour(application).
 
 %% Application callbacks
--export([start/2, stop/1,loop/0,parseExpr/1,splitByDots/1,parse/1]).
+-export([start/2, stop/1,loop/0,splitByDots/1]).
 -include_lib("eunit/include/eunit.hrl").
 
 
@@ -118,8 +118,14 @@ splitByDots([H|T],Acc,Final)->
       true ->
         splitByDots(T,lists:append(Acc,[H]),Final)
     end;
-splitByDots([],_,Final)->
-  Final.
+splitByDots([],Acc,Final)->
+    if
+      length(Acc) == 0 ->
+        Res = Final;
+      true ->
+        Res =lists:append(Final,[Acc])
+    end,
+    Res.
 
 %% Format do a conversion of erlang tuples to list, also change strings to binaries
 format(T) when is_list(T)->
@@ -182,3 +188,21 @@ format_test_()->
    ?_assert(format({"hello","world"})=:= [<<"hello">>,<<"world">>]),
    ?_assert(format({a,b,[c,"hello",{"world",["this","is","a","test"]}]})=:= [a,b,[c,<<"hello">>,[<<"world">>,[<<"this">>,<<"is">>,<<"a">>,<<"test">>]]]]),
    ?_assert(format({"hello",<<"world">>})=:= [<<"hello">>,<<"world">>])].
+
+ splitByDots_test_()->
+   String1 = "ok . ok . ok . ok",
+   String2 = ". . . . ok",
+   String3 = "ok",
+   String4 = ".",
+   {_,Tokens1,_} = erl_scan:string(String1),
+   {_,Tokens2,_} = erl_scan:string(String2),
+   {_,Tokens3,_} = erl_scan:string(String3),
+   {_,Tokens4,_} = erl_scan:string(String4),
+   Res1 = length(splitByDots(Tokens1)),
+   Res2 = length(splitByDots(Tokens2)),
+   Res3 = length(splitByDots(Tokens3)),
+   Res4 = length(splitByDots(Tokens4)),
+   [?_assertEqual(4,Res1),
+   ?_assertEqual(5,Res2),
+   ?_assertEqual(1,Res3),
+   ?_assertEqual(1,Res4)].

--- a/native/src/driver_app.erl
+++ b/native/src/driver_app.erl
@@ -11,7 +11,7 @@
 start(_StartType, _StartArgs) ->
     try
       %If you are modifying the code comment the next line to show the exceptions
-      %error_logger:tty(false),
+      error_logger:tty(false),
       loop()
     catch
       throw:{eofErr,_}->
@@ -88,7 +88,6 @@ tokenize(Content) ->
     end,
     TokExprList.
 
-
 parse(ExprList) ->
     List = lists:foldl(fun (Expr,ParseList)->
       case parseExpr(Expr) of
@@ -120,10 +119,7 @@ splitByDots([H|T],Acc,Final)->
         splitByDots(T,lists:append(Acc,[H]),Final)
     end;
 splitByDots([],_,Final)->
-  io:format("~p~n",[Final]),
   Final.
-
-
 
 %% Format do a conversion of erlang tuples to list, also change strings to binaries
 format(T) when is_list(T)->


### PR DESCRIPTION
This PR solves #6. The approach that was taken, was to use the erl_scan library for all the code and then divide in expressions instead of dividing in expressions and then tokenize.

## Changes
- Tokenize now use the erl_scan:string method
- SplitByDots, takes the Tokens and divide into sublists for the parser
- Parse now only call parseExpr taking as input the list of lists given by SplitByDots
- Added some unit test to check the right working of SplitByDots

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/erlang-driver/7)
<!-- Reviewable:end -->
